### PR TITLE
Fixes improper DMB path handling

### DIFF
--- a/src/tests.ts
+++ b/src/tests.ts
@@ -343,7 +343,7 @@ async function runDMB(path: string, workspace: vscode.WorkspaceFolder, cancelEmi
 	}
 
 	const ddpath = await config.getDreamdaemonExecutable();
-	const args = [path, '-close', '-trusted', '-verbose'];
+	const args = [`"${path}"`, '-close', '-trusted', '-verbose'];
 	if (resultsType === config.ResultType.Log) {
 		args.push('-params', '"log-directory=unit_test"');
 	}


### PR DESCRIPTION
Fixes #9 - An issue where spaces in workspace paths cause runs to fail.

This was due to not properly enclosing the path of the DMB given to DreamDeamon in quotations, resulting the path being interpreted as multiple separate parameters.

Tested the fix locally and it works like a charm.
![image](https://github.com/user-attachments/assets/3309cf68-c7f5-462c-b094-14cce92e831c)
